### PR TITLE
APIサーバーの実装を確認するCIを追加

### DIFF
--- a/.github/workflows/api-test-and-linter.yml
+++ b/.github/workflows/api-test-and-linter.yml
@@ -1,0 +1,27 @@
+name: API Test and Linter CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          docker compose up -d --build
+          while ! docker compose exec mysql_server mysqladmin --user=root --password=${{ secrets.MYSQL_ROOT_PASSWORD }} --host "mysql_server" ping --silent &> /dev/null; do
+            sleep 1
+          done
+          docker compose exec api_server bundle exec rails db:create
+          docker compose exec -e RAILS_ENV=test api_server bundle exec ridgepole --config ./config/database.yml --apply
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+
+      - name: Run RuboCop linter
+        run: docker compose exec -e RAILS_ENV=test api_server bundle exec rubocop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       TZ: "Asia/Tokyo"
       DATABASE_HOST: mysql_server
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
     networks:
       - api_network
   mysql_server:
@@ -30,6 +31,7 @@ services:
     restart: unless-stopped
     environment:
       TZ: "Asia/Tokyo"
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
     networks:
       - api_network
     healthcheck:


### PR DESCRIPTION
# やったこと
APIサーバーの実装を確認するCIを追加した
ついでにMySQLサーバーの状態がHealthyになってからAPIサーバーを起動するようにした

SQLサーバーの応答を待つ必要がある点の対応について、docker-compose.yml内で、dockerizeを使ってAPIサーバーの起動を待つcommandを定義する方法も検討したが、結局シェルスクリプト側で待つ必要があったのでやめた。

# 関連資料
- Docker-docs-ja --env-file オプションを使う: https://docs.docker.jp/compose/environment-variables.html#id13
- Github Actionsの使い方メモ: https://qiita.com/HeRo/items/935d5e268208d411ab5a
- docker-compose + Github ActionsでRepositoryのテスト環境構築を楽にする: https://zenn.dev/tady/articles/6835738bb96c0e
- 【GitHub Actions】.envファイルを使用する: https://zenn.dev/big_tanukiudon/articles/fc1a2ff562ce3d

`Error:  Invalid config: 'scheme' is empty: "./app/config/database.yml"`のエラーが出たが、これはdatabase.ymlのパスが間違っていた
- https://github.com/ridgepole/ridgepole/blob/272ecdb9ff30d8522b21d53d88c43b9923d02bd1/spec/mysql/cli/config_spec.rb#L102